### PR TITLE
feat: add health log tracker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Breevia - 个人定制养生平台
 
-一个基于 Next.js、Tailwind CSS 和 Supabase 构建的个人定制养生平台，专注于提供个性化食谱、补剂推荐和医学级健康方案。
+一个基于 Next.js、Tailwind CSS 和 Supabase 构建的个人健康追踪与定制养生平台，专注于提供个性化健康日志、食谱推荐、补剂管理和医学级健康方案。
 
 ## ✨ 核心功能
 
@@ -9,6 +9,11 @@
 - 今日营养摄入和补剂服用提醒
 - 健康计划进度跟踪
 - 个性化健康建议展示
+
+### 📊 健康追踪日志
+- 记录每日体重、心情、睡眠质量等
+- 简易表单支持日期、体重、心情和备注录入
+- 查看历史趋势和备注
 
 ### 🍽️ 定制食谱系统
 - 基于个人体质和健康目标的食谱推荐
@@ -56,6 +61,7 @@ Breevia/
 │   ├── AuthForm.tsx       # 认证表单
 │   ├── Sidebar.tsx        # 侧边导航栏
 │   ├── HealthDashboard.tsx      # 健康仪表板
+│   ├── HealthTracker.tsx       # 健康记录
 │   ├── NutritionRecipes.tsx     # 营养食谱
 │   ├── SupplementHub.tsx   # 智能补剂
 │   └── AIAgents.tsx       # AI 健康顾问

--- a/app/page.tsx
+++ b/app/page.tsx
@@ -5,19 +5,13 @@ import { motion, AnimatePresence } from 'framer-motion'
 import AuthForm from '@/components/AuthForm'
 import Sidebar from '@/components/Sidebar'
 import HealthDashboard from '@/components/HealthDashboard'
+import HealthTracker from '@/components/HealthTracker'
 import NutritionRecipes from '@/components/NutritionRecipes'
 import SupplementHub from '@/components/SupplementHub'
 import AIAgents from '@/components/AIAgents'
-import DesignSystemDemo from '@/components/DesignSystemDemo'
 import { getCurrentUser, onAuthStateChange, type AuthUser } from '@/lib/auth'
 
 export default function Home() {
-  // 暂时显示设计系统演示，您可以根据需要切换回原来的逻辑
-  const showDesignDemo = true;
-  
-  if (showDesignDemo) {
-    return <DesignSystemDemo />
-  }
   const [user, setUser] = useState<AuthUser | null>(null)
   const [loading, setLoading] = useState(true)
   const [authMode, setAuthMode] = useState<'signin' | 'signup'>('signin')
@@ -49,6 +43,8 @@ export default function Home() {
     switch (activeTab) {
       case 'dashboard':
         return <HealthDashboard user={user} />
+      case 'health-logs':
+        return <HealthTracker />
       case 'recipes':
         return <NutritionRecipes />
       case 'supplements':

--- a/components/HealthTracker.tsx
+++ b/components/HealthTracker.tsx
@@ -1,0 +1,103 @@
+'use client'
+
+import { useState } from 'react'
+import { PlusCircle } from 'lucide-react'
+
+interface HealthLog {
+  date: string
+  weight: string
+  mood: string
+  notes: string
+}
+
+export default function HealthTracker() {
+  const [logs, setLogs] = useState<HealthLog[]>([])
+  const [form, setForm] = useState<HealthLog>({
+    date: new Date().toISOString().split('T')[0],
+    weight: '',
+    mood: '',
+    notes: ''
+  })
+
+  const addLog = () => {
+    if (!form.weight && !form.mood && !form.notes) return
+    setLogs([...logs, form])
+    setForm({ ...form, weight: '', mood: '', notes: '' })
+  }
+
+  return (
+    <div className="flex-1 p-6 bg-gradient-to-br from-green-50 via-blue-50 to-purple-50 overflow-y-auto">
+      <div className="max-w-2xl mx-auto">
+        <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6 mb-6">
+          <h2 className="text-2xl font-bold text-gray-900 mb-4">记录今日健康</h2>
+          <div className="grid gap-4 md:grid-cols-2">
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">日期</label>
+              <input
+                type="date"
+                value={form.date}
+                onChange={e => setForm({ ...form, date: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">体重 (kg)</label>
+              <input
+                type="number"
+                value={form.weight}
+                onChange={e => setForm({ ...form, weight: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+            </div>
+            <div>
+              <label className="block text-sm font-medium text-gray-700 mb-1">心情 (1-10)</label>
+              <input
+                type="number"
+                min={1}
+                max={10}
+                value={form.mood}
+                onChange={e => setForm({ ...form, mood: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+              />
+            </div>
+            <div className="md:col-span-2">
+              <label className="block text-sm font-medium text-gray-700 mb-1">备注</label>
+              <textarea
+                value={form.notes}
+                onChange={e => setForm({ ...form, notes: e.target.value })}
+                className="w-full px-3 py-2 border border-gray-300 rounded-lg"
+                rows={3}
+              />
+            </div>
+          </div>
+          <button
+            onClick={addLog}
+            className="mt-4 inline-flex items-center px-4 py-2 bg-green-600 text-white rounded-lg hover:bg-green-700"
+          >
+            <PlusCircle className="h-4 w-4 mr-2" />
+            添加记录
+          </button>
+        </div>
+
+        {logs.length > 0 && (
+          <div className="bg-white rounded-xl shadow-sm border border-gray-100 p-6">
+            <h3 className="text-xl font-semibold text-gray-900 mb-4">历史记录</h3>
+            <ul className="space-y-3">
+              {logs.map((log, index) => (
+                <li key={index} className="p-4 border border-gray-100 rounded-lg">
+                  <div className="flex flex-wrap items-center justify-between text-sm text-gray-600">
+                    <span>{log.date}</span>
+                    {log.weight && <span>{log.weight} kg</span>}
+                    {log.mood && <span>心情 {log.mood}/10</span>}
+                  </div>
+                  {log.notes && <p className="mt-1 text-gray-700">{log.notes}</p>}
+                </li>
+              ))}
+            </ul>
+          </div>
+        )}
+      </div>
+    </div>
+  )
+}
+

--- a/components/Sidebar.tsx
+++ b/components/Sidebar.tsx
@@ -28,6 +28,7 @@ interface SidebarProps {
 
 const menuItems = [
   { id: 'dashboard', label: '健康仪表板', icon: Home },
+  { id: 'health-logs', label: '健康记录', icon: Activity },
   { id: 'recipes', label: '营养食谱', icon: ChefHat },
   { id: 'supplements', label: '智能补剂', icon: Pill },
   { id: 'health-plans', label: '健康方案', icon: FileText },


### PR DESCRIPTION
## Summary
- add HealthTracker component to log date, weight, mood and notes
- expose new "健康记录" tab in sidebar and render tracker on main page
- update README to emphasize personal health logging

## Testing
- `npm test` (fails: Missing script "test")
- `npm run lint` (prompts for ESLint configuration)


------
https://chatgpt.com/codex/tasks/task_e_68a8e108b938832abccde0ad0a0b4ee8